### PR TITLE
feat: implement api-key technology

### DIFF
--- a/src/auth/checkAuth.js
+++ b/src/auth/checkAuth.js
@@ -1,0 +1,52 @@
+' use strict '
+
+const { findById } = require("../services/apiKey.service");
+
+const HEADER = {
+    API_KEY: 'x-api-key',
+    AUTHORIZATION: 'authorization'
+}
+const apiKey = async(req, res, next) => {
+    try {
+        const key = req.headers[HEADER.API_KEY]?.toString();
+        if(!key) {
+            return res.status(403).json({
+                message: 'Forbiden Error',
+            })
+        }
+        //checkObject
+        const objKey = await findById(key);
+        if(!objKey) {
+            return res.status(403).json({
+                message: 'Forbiden Error',
+            })
+        }
+        req.objKey = objKey;
+         return next()
+    } catch (error) {
+        console.log(error);
+    }
+}
+
+// Closure func: return a fn which can use all props of its parent's func
+const permission = (permission) => {
+    return (req, res, next) => {
+        if(!req?.objKey?.permissions) {
+            return res.status(403).json({
+                message: 'Permission Denied',
+            }) 
+        }
+        console.log('permission:::', req.objKey.permissions);
+        const validPermission = req.objKey.permissions.includes(permission);
+        if(!validPermission){
+            return res.status(403).json({
+                message: 'Permission Denied',
+            }) 
+        }
+        return next();
+    }
+}
+module.exports = {
+    apiKey,
+    permission
+}

--- a/src/models/apiKey.model.js
+++ b/src/models/apiKey.model.js
@@ -1,0 +1,30 @@
+' use strict '
+
+const mongoose = require('mongoose'); // Erase if already required
+
+const DOCUMENT_NAME = 'ApiKey';
+const COLLECTION_NAME = 'ApiKeys';
+
+// Declare the Schema of the Mongo model
+var apiKeySchema = new mongoose.Schema({
+    key: {
+        type: String,
+        required: true,
+        unique: true,
+    },
+    status: {
+        type: Boolean,
+        default: true,
+    },
+    permissions: {
+        type: [String],
+        required: true,
+        enum: ['0000', '1111', '2222']
+    },
+}, {
+    timestamps: true,
+    collection: COLLECTION_NAME
+});
+
+//Export the model
+module.exports = mongoose.model(DOCUMENT_NAME, apiKeySchema);

--- a/src/postman/access.post.http
+++ b/src/postman/access.post.http
@@ -4,6 +4,7 @@
 
 POST {{url_dev}}/shop/signup
 Content-Type: application/json
+x-api-key: 0cef15eb0745a88cb40ddd2dfa8dc40538623300ef63379d0e36f57b5b2fce47f614eda328620dff2be536bed3de3b2b743fd71b26b5dc61a07d2c4971241fa0
 
 {
     "name": "ShopTips3",

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,13 +1,20 @@
 'use strict'
 
 const express = require('express');
+const { apiKey, permission } = require('../auth/checkAuth');
 const router = express.Router();
 
+/*
+Need to check whether current system use our API or not:
+--> check API key
+--> Check permission
+*/
+// check api key
+router.use(apiKey)
+// check permission
+router.use(permission('0000'))
+
+
 router.use('/v1/api', require('./access'))
-// router.get('', (req, res, next) => {
-    // return res.status(200).json({
-        // message: 'Welcome '
-    // })
-// })
 
 module.exports = router

--- a/src/services/apiKey.service.js
+++ b/src/services/apiKey.service.js
@@ -1,0 +1,14 @@
+' use strict '
+
+const apiKeyModel = require("../models/apiKey.model");
+const crypto = require("crypto");
+
+const findById = async (key) => {
+    const newKey = await apiKeyModel.create({key: crypto.randomBytes(64).toString('hex'), permissions: ['0000']});
+    console.log(newKey);
+    const objKey = await apiKeyModel.findOne({key: key, status: true}).lean();
+    return objKey
+}
+module.exports = {
+    findById
+}


### PR DESCRIPTION
API Key Use Cases:
- API Rate Limiting: API keys are often used to track and control the usage of an API by different applications. This helps prevent abuse and overloading of the API server.
- Basic Access Control: For simple scenarios where a basic level of access control is needed, API keys can be used to restrict access to specific endpoints or resources.
- Third-Party Integrations: API keys are commonly used by third-party applications to integrate with other services or APIs, where the third party is not directly handling user identity.
- Usage Analytics: API keys are valuable for tracking how different applications are using your API. They provide insights into usage patterns and can help identify popular features.